### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@rainbow-me/rainbowkit@2.1.0/dist/index.css" />
       </head>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,7 @@ import { FilterPanel } from "@/components/filter-panel"
 import { FilterChips } from "@/components/filter-chips"
 import { OraCardCollectible } from "@/components/ora-card-collectible-updated"
 import { WalletConnect } from "@/components/wallet-connect"
+import { ThemeToggle } from "@/components/theme-toggle"
 import { useFilterStore } from "@/lib/store"
 import { Badge } from "@/components/ui/badge"
 import { DEFAULT_CMP_DATA, type CMPData } from "@/components/cmp-data-types"
@@ -416,6 +417,7 @@ export default function OraDashboard() {
               </Button>
             )}
             <WalletConnect />
+            <ThemeToggle />
           </div>
         </div>
       </div>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,6 +4,7 @@ import type * as React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { WagmiProvider } from "wagmi"
 import { RainbowKitProvider, lightTheme } from "@rainbow-me/rainbowkit"
+import { ThemeProvider } from "@/components/theme-provider"
 
 import { config } from "@/lib/wagmi"
 
@@ -11,26 +12,28 @@ const queryClient = new QueryClient()
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <WagmiProvider config={config}>
-      <QueryClientProvider client={queryClient}>
-        <RainbowKitProvider
-          theme={lightTheme({
-            accentColor: "#3b82f6",
-            accentColorForeground: "white",
-            borderRadius: "large",
-            fontStack: "system",
-            overlayBlur: "small",
-          })}
-          modalSize="compact"
-          showRecentTransactions={true}
-          appInfo={{
-            appName: "Sugartown Ora Dashboard",
-            learnMoreUrl: "https://sugartown.com",
-          }}
-        >
-          {children}
-        </RainbowKitProvider>
-      </QueryClientProvider>
-    </WagmiProvider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <WagmiProvider config={config}>
+        <QueryClientProvider client={queryClient}>
+          <RainbowKitProvider
+            theme={lightTheme({
+              accentColor: "#3b82f6",
+              accentColorForeground: "white",
+              borderRadius: "large",
+              fontStack: "system",
+              overlayBlur: "small",
+            })}
+            modalSize="compact"
+            showRecentTransactions={true}
+            appInfo={{
+              appName: "Sugartown Ora Dashboard",
+              learnMoreUrl: "https://sugartown.com",
+            }}
+          >
+            {children}
+          </RainbowKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>
+    </ThemeProvider>
   )
 }

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useTheme } from "next-themes"
+import { Button } from "@/components/ui/button"
+import { Moon, Sun } from "lucide-react"
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
+  if (!mounted) return null
+
+  const isDark = resolvedTheme === "dark"
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label="Toggle theme"
+    >
+      <Sun className={isDark ? "hidden" : "h-4 w-4"} />
+      <Moon className={isDark ? "h-4 w-4" : "hidden"} />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- wrap app with NextThemes `ThemeProvider`
- implement `ThemeToggle` component
- include toggle in header bar
- suppress hydration warning on html element

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run build` *(fails: viem actions not exported)*

------
https://chatgpt.com/codex/tasks/task_e_688c387733948323a0b2a0dfccb2cdac